### PR TITLE
rest of pages unit tests

### DIFF
--- a/__tests__/_app.unit.spec.tsx
+++ b/__tests__/_app.unit.spec.tsx
@@ -1,0 +1,49 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { render, screen } from '../utils/testUtil';
+import { MockedProvider } from '@apollo/client/testing';
+import { useRouter } from 'next/router';
+import AppPage from '../pages/_app';
+
+jest.mock('next/router', () => ({
+  useRouter() {
+    return {
+      route: '/',
+      pathname: '',
+      query: '',
+      asPath: '',
+    };
+  },
+}));
+
+const props = {
+  Component: () => null,
+  pageProps: {},
+};
+
+it('tells you where you are', () => {
+  render(
+    <MockedProvider mocks={[]} addTypename={false}>
+      <AppPage {...props} />
+    </MockedProvider>
+  );
+  expect(screen.getByText('Pick’em')).toBeInTheDocument();
+});
+
+it('displays layout if component contains layout property', () => {
+  const getLayout = function getLayout(page) {
+    return <div data-testid="layout-wrapper">{page}</div>;
+  };
+  const componentWithLayout = () => null;
+  componentWithLayout.getLayout = getLayout;
+  const props = {
+    Component: componentWithLayout,
+    pageProps: {},
+  };
+  render(
+    <MockedProvider mocks={[]} addTypename={false}>
+      <AppPage {...props} />
+    </MockedProvider>
+  );
+  expect(screen.getByTestId('layout-wrapper')).toBeInTheDocument();
+});

--- a/__tests__/gameResults.unit.spec.tsx
+++ b/__tests__/gameResults.unit.spec.tsx
@@ -1,0 +1,12 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { render, screen } from '../utils/testUtil';
+import GameResultsPage from '../pages/game-results';
+
+it('tells you where you are', () => {
+  render(
+    <MockedProvider mocks={[]} addTypename={false}>
+      <GameResultsPage />
+    </MockedProvider>
+  );
+  expect(screen.getByText('Game Results')).toBeInTheDocument();
+});

--- a/__tests__/manageGame.unit.spec.tsx
+++ b/__tests__/manageGame.unit.spec.tsx
@@ -2,8 +2,7 @@ import { MockedProvider } from '@apollo/client/testing';
 import { useRouter } from 'next/router';
 import { GraphQLError } from 'graphql';
 import { render, screen, waitFor } from '../utils/testUtil';
-import {
-  ManageGamePage,
+import ManageGamePage, {
   GET_GAME_BY_SLUG_QUERY,
 } from '../pages/manage-games/[season]/[week]/[game]/index';
 import { GET_WEEK_BY_SLUG_QUERY } from '../pages/manage-games/[season]/[week]/index';

--- a/__tests__/manageGame.unit.spec.tsx
+++ b/__tests__/manageGame.unit.spec.tsx
@@ -1,0 +1,324 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { useRouter } from 'next/router';
+import { GraphQLError } from 'graphql';
+import { render, screen, waitFor } from '../utils/testUtil';
+import {
+  ManageGamePage,
+  GET_GAME_BY_SLUG_QUERY,
+} from '../pages/manage-games/[season]/[week]/[game]/index';
+import { GET_WEEK_BY_SLUG_QUERY } from '../pages/manage-games/[season]/[week]/index';
+import { CURRENT_PLAYER_QUERY } from '../lib/usePlayer';
+import { fakePlayer, fakeWeek, fakeGame } from '../utils/testData';
+
+const season = '2021';
+const weekSlug = 'week-1';
+const gameSlug = 'falcons-jaguars';
+
+const week = fakeWeek();
+const game = fakeGame();
+
+const gamesMock = [
+  {
+    request: {
+      query: GET_WEEK_BY_SLUG_QUERY,
+      variables: { season, slug: weekSlug },
+    },
+    result: {
+      data: { weeks: [week] },
+    },
+  },
+  {
+    request: {
+      query: GET_GAME_BY_SLUG_QUERY,
+      variables: { season, slug: gameSlug },
+    },
+    result: {
+      data: { games: [game] },
+    },
+  },
+];
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: jest.fn(),
+}));
+const mockRouter = {
+  query: { season, week: weekSlug, game: gameSlug },
+};
+(useRouter as jest.Mock).mockReturnValue(mockRouter);
+
+it('tells you where you are', async () => {
+  render(
+    <MockedProvider mocks={gamesMock} addTypename={false}>
+      <ManageGamePage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText('Manage Games')).toBeInTheDocument();
+  });
+});
+it('displays loading message if weeks data not yet returned', async () => {
+  const gamesMock = [
+    {
+      request: {
+        query: GET_GAME_BY_SLUG_QUERY,
+        variables: { season, slug: gameSlug },
+      },
+      result: {
+        data: { games: [game] },
+      },
+    },
+  ];
+  render(
+    <MockedProvider mocks={gamesMock} addTypename={false}>
+      <ManageGamePage />
+    </MockedProvider>
+  );
+  expect(screen.getByText('Loading...')).toBeInTheDocument();
+});
+
+it('displays loading message if game data not yet returned', async () => {
+  const gamesMock = [
+    {
+      request: {
+        query: GET_WEEK_BY_SLUG_QUERY,
+        variables: { season, slug: weekSlug },
+      },
+      result: {
+        data: { weeks: [week] },
+      },
+    },
+  ];
+  render(
+    <MockedProvider mocks={gamesMock} addTypename={false}>
+      <ManageGamePage />
+    </MockedProvider>
+  );
+  expect(screen.getByText('Loading...')).toBeInTheDocument();
+});
+it('displays error if weeks array is empty', async () => {
+  const gamesMock = [
+    {
+      request: {
+        query: GET_WEEK_BY_SLUG_QUERY,
+        variables: { season, slug: weekSlug },
+      },
+      result: {
+        data: { weeks: [] },
+      },
+    },
+    {
+      request: {
+        query: GET_GAME_BY_SLUG_QUERY,
+        variables: { season, slug: gameSlug },
+      },
+      result: {
+        data: { games: [game] },
+      },
+    },
+  ];
+  render(
+    <MockedProvider mocks={gamesMock} addTypename={false}>
+      <ManageGamePage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText(/week not found/i)).toBeInTheDocument();
+  });
+});
+
+it('displays error if game data is empty', async () => {
+  const gamesMock = [
+    {
+      request: {
+        query: GET_WEEK_BY_SLUG_QUERY,
+        variables: { season, slug: weekSlug },
+      },
+      result: {
+        data: { weeks: [week] },
+      },
+    },
+    {
+      request: {
+        query: GET_GAME_BY_SLUG_QUERY,
+        variables: { season, slug: gameSlug },
+      },
+      result: {
+        data: { games: [] },
+      },
+    },
+  ];
+  render(
+    <MockedProvider mocks={gamesMock} addTypename={false}>
+      <ManageGamePage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText(/game not found/i)).toBeInTheDocument();
+  });
+});
+it('displays error if network error returned from get weeks', async () => {
+  const gamesMock = [
+    {
+      request: {
+        query: GET_WEEK_BY_SLUG_QUERY,
+        variables: { season, slug: weekSlug },
+      },
+      error: new Error('[Network error]: An error occurred'),
+    },
+    {
+      request: {
+        query: GET_GAME_BY_SLUG_QUERY,
+        variables: { season, slug: gameSlug },
+      },
+      result: {
+        data: { games: [game] },
+      },
+    },
+  ];
+  render(
+    <MockedProvider mocks={gamesMock} addTypename={false}>
+      <ManageGamePage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText(/[Network Error]/i)).toBeInTheDocument();
+  });
+});
+it('displays error if graphql error returned from get weeks', async () => {
+  const gamesMock = [
+    {
+      request: {
+        query: GET_WEEK_BY_SLUG_QUERY,
+        variables: { season, slug: weekSlug },
+      },
+      result: {
+        errors: [new GraphQLError('[GraphQL error]: Error!')],
+      },
+    },
+    {
+      request: {
+        query: GET_GAME_BY_SLUG_QUERY,
+        variables: { season, slug: gameSlug },
+      },
+      result: {
+        data: { games: [game] },
+      },
+    },
+  ];
+  render(
+    <MockedProvider mocks={gamesMock} addTypename={false}>
+      <ManageGamePage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText(/[Graphql Error]/i)).toBeInTheDocument();
+  });
+});
+it('displays error if network error returned from get game', async () => {
+  const gamesMock = [
+    {
+      request: {
+        query: GET_WEEK_BY_SLUG_QUERY,
+        variables: { season, slug: weekSlug },
+      },
+      result: {
+        data: { weeks: [week] },
+      },
+    },
+    {
+      request: {
+        query: GET_GAME_BY_SLUG_QUERY,
+        variables: { season, slug: gameSlug },
+      },
+      error: new Error('[Network error]: An error occurred'),
+    },
+  ];
+  render(
+    <MockedProvider mocks={gamesMock} addTypename={false}>
+      <ManageGamePage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText(/[Network Error]/i)).toBeInTheDocument();
+  });
+});
+it('displays error if graphql error returned from get game', async () => {
+  const gamesMock = [
+    {
+      request: {
+        query: GET_WEEK_BY_SLUG_QUERY,
+        variables: { season, slug: weekSlug },
+      },
+      result: {
+        data: { weeks: [week] },
+      },
+    },
+    {
+      request: {
+        query: GET_GAME_BY_SLUG_QUERY,
+        variables: { season, slug: gameSlug },
+      },
+      result: {
+        errors: [new GraphQLError('[GraphQL error]: Error!')],
+      },
+    },
+  ];
+  render(
+    <MockedProvider mocks={gamesMock} addTypename={false}>
+      <ManageGamePage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText(/[Graphql Error]/i)).toBeInTheDocument();
+  });
+});
+it('displays login form if player is not logged in', async () => {
+  render(
+    <MockedProvider mocks={gamesMock} addTypename={false}>
+      <ManageGamePage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    const signInHeading = screen.getAllByRole('heading', { level: 2 })[0];
+    expect(signInHeading).toHaveTextContent('Sign Into Your Account');
+
+    const resetHeading = screen.getAllByRole('heading', { level: 2 })[1];
+    expect(resetHeading).toHaveTextContent('Request a Password Reset');
+  });
+});
+it('displays page if player is logged in', async () => {
+  const gamesMock = [
+    {
+      request: {
+        query: GET_WEEK_BY_SLUG_QUERY,
+        variables: { season, slug: weekSlug },
+      },
+      result: {
+        data: { weeks: [week] },
+      },
+    },
+    {
+      request: {
+        query: GET_GAME_BY_SLUG_QUERY,
+        variables: { season, slug: gameSlug },
+      },
+      result: {
+        data: { games: [game] },
+      },
+    },
+    {
+      request: { query: CURRENT_PLAYER_QUERY },
+      result: { data: { authenticatedItem: fakePlayer() } },
+    },
+  ];
+
+  render(
+    <MockedProvider mocks={gamesMock} addTypename={false}>
+      <ManageGamePage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText('Falcons vs Jaguars')).toBeInTheDocument();
+  });
+});

--- a/__tests__/manageGames.unit.spec.tsx
+++ b/__tests__/manageGames.unit.spec.tsx
@@ -1,0 +1,154 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { GraphQLError } from 'graphql';
+import { useRouter } from 'next/router';
+import { render, screen, waitFor } from '../utils/testUtil';
+import {
+  ManageGamesPage,
+  GET_WEEK_BY_SLUG_QUERY,
+} from '../pages/manage-games/[season]/[week]/index';
+import { CURRENT_PLAYER_QUERY } from '../lib/usePlayer';
+import { fakePlayer, fakeWeek } from '../utils/testData';
+
+const week = fakeWeek();
+
+const weeksMock = [
+  {
+    request: {
+      query: GET_WEEK_BY_SLUG_QUERY,
+      variables: { season: '2021', slug: 'week-1' },
+    },
+    result: {
+      data: { weeks: [week] },
+    },
+  },
+];
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: jest.fn(),
+}));
+const mockRouter = {
+  query: { season: '2021', week: 'week-1' },
+};
+(useRouter as jest.Mock).mockReturnValue(mockRouter);
+
+it('tells you where you are', async () => {
+  render(
+    <MockedProvider mocks={weeksMock} addTypename={false}>
+      <ManageGamesPage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText('Manage Games')).toBeInTheDocument();
+  });
+});
+it('displays loading message if data not yet returned', async () => {
+  render(
+    <MockedProvider mocks={[]} addTypename={false}>
+      <ManageGamesPage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+});
+it('displays error if weeks array is empty', async () => {
+  const weeksMockNoWeeks = [
+    {
+      request: {
+        query: GET_WEEK_BY_SLUG_QUERY,
+        variables: { season: '2021', slug: 'week-1' },
+      },
+      result: {
+        data: { weeks: [] },
+      },
+    },
+  ];
+  render(
+    <MockedProvider mocks={weeksMockNoWeeks} addTypename={false}>
+      <ManageGamesPage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+});
+it('displays error if network error returned from backend', async () => {
+  const weeksMockNetworkError = [
+    {
+      request: {
+        query: GET_WEEK_BY_SLUG_QUERY,
+        variables: { season: '2021', slug: 'week-1' },
+      },
+      error: new Error('[Network error]: An error occurred'),
+    },
+  ];
+  render(
+    <MockedProvider mocks={weeksMockNetworkError} addTypename={false}>
+      <ManageGamesPage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+});
+it('displays error if graphql error returned from database', async () => {
+  const weeksMockGraphqlError = [
+    {
+      request: {
+        query: GET_WEEK_BY_SLUG_QUERY,
+        variables: { season: '2021', slug: 'week-1' },
+      },
+      result: {
+        errors: [new GraphQLError('[GraphQL error]: Error!')],
+      },
+    },
+  ];
+  render(
+    <MockedProvider mocks={weeksMockGraphqlError} addTypename={false}>
+      <ManageGamesPage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+});
+it('displays login form if player is not logged in', async () => {
+  render(
+    <MockedProvider mocks={weeksMock} addTypename={false}>
+      <ManageGamesPage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    const signInHeading = screen.getAllByRole('heading', { level: 2 })[0];
+    expect(signInHeading).toHaveTextContent('Sign Into Your Account');
+
+    const resetHeading = screen.getAllByRole('heading', { level: 2 })[1];
+    expect(resetHeading).toHaveTextContent('Request a Password Reset');
+  });
+});
+it('displays page if player is logged in', async () => {
+  const weeksMock = [
+    {
+      request: {
+        query: GET_WEEK_BY_SLUG_QUERY,
+        variables: { season: '2021', slug: 'week-1' },
+      },
+      result: {
+        data: { weeks: [week] },
+      },
+    },
+    {
+      request: { query: CURRENT_PLAYER_QUERY },
+      result: { data: { authenticatedItem: fakePlayer() } },
+    },
+  ];
+  render(
+    <MockedProvider mocks={weeksMock} addTypename={false}>
+      <ManageGamesPage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText('Add New Game')).toBeInTheDocument();
+  });
+});

--- a/__tests__/manageGames.unit.spec.tsx
+++ b/__tests__/manageGames.unit.spec.tsx
@@ -2,8 +2,7 @@ import { MockedProvider } from '@apollo/client/testing';
 import { GraphQLError } from 'graphql';
 import { useRouter } from 'next/router';
 import { render, screen, waitFor } from '../utils/testUtil';
-import {
-  ManageGamesPage,
+import ManageGamesPage, {
   GET_WEEK_BY_SLUG_QUERY,
 } from '../pages/manage-games/[season]/[week]/index';
 import { CURRENT_PLAYER_QUERY } from '../lib/usePlayer';

--- a/__tests__/manageWeeks.unit.spec.tsx
+++ b/__tests__/manageWeeks.unit.spec.tsx
@@ -1,0 +1,43 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { render, screen, waitFor } from '../utils/testUtil';
+import { CURRENT_PLAYER_QUERY } from '../lib/usePlayer';
+import { fakePlayer } from '../utils/testData';
+import ManageWeeksPage from '../pages/manage-games/[season]/index';
+
+const manageWeeksMocks = [
+  {
+    request: { query: CURRENT_PLAYER_QUERY },
+    result: { data: { authenticatedItem: fakePlayer() } },
+  },
+];
+
+it('tells you where you are', () => {
+  render(
+    <MockedProvider mocks={[]} addTypename={false}>
+      <ManageWeeksPage />
+    </MockedProvider>
+  );
+  expect(screen.getByText('Manage Games')).toBeInTheDocument();
+});
+it('displays login form if player is not logged in', async () => {
+  render(
+    <MockedProvider mocks={[]} addTypename={false}>
+      <ManageWeeksPage />
+    </MockedProvider>
+  );
+  const signInHeading = screen.getAllByRole('heading', { level: 2 })[0];
+  expect(signInHeading).toHaveTextContent('Sign Into Your Account');
+
+  const resetHeading = screen.getAllByRole('heading', { level: 2 })[1];
+  expect(resetHeading).toHaveTextContent('Request a Password Reset');
+});
+it('displays page if player is logged in', async () => {
+  render(
+    <MockedProvider mocks={manageWeeksMocks} addTypename={false}>
+      <ManageWeeksPage />
+    </MockedProvider>
+  );
+  await waitFor(() => {
+    expect(screen.getByText('Add New Week')).toBeInTheDocument();
+  });
+});

--- a/__tests__/reset.unit.spec.tsx
+++ b/__tests__/reset.unit.spec.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '../utils/testUtil';
+import { MockedProvider } from '@apollo/client/testing';
+import { useRouter } from 'next/router';
+import ResetPage from '../pages/reset';
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  useRouter: jest.fn(),
+}));
+
+it('tells you where you are', () => {
+  const mockRouter = {
+    query: { token: '12345' },
+  };
+  (useRouter as jest.Mock).mockReturnValue(mockRouter);
+  render(
+    <MockedProvider mocks={[]} addTypename={false}>
+      <ResetPage />
+    </MockedProvider>
+  );
+  expect(
+    screen.getByRole('heading', { level: 2, name: 'Reset Your Password' })
+  ).toBeInTheDocument();
+});
+
+it('displays a message if no token provided', () => {
+  const mockRouter = {
+    query: {},
+  };
+  (useRouter as jest.Mock).mockReturnValue(mockRouter);
+  render(
+    <MockedProvider mocks={[]} addTypename={false}>
+      <ResetPage />
+    </MockedProvider>
+  );
+  expect(screen.getByText('Sorry you must supply a token')).toBeInTheDocument();
+});

--- a/pages/manage-games/[season]/[week]/[game]/index.tsx
+++ b/pages/manage-games/[season]/[week]/[game]/index.tsx
@@ -53,7 +53,7 @@ export const GET_GAME_BY_SLUG_QUERY = gql`
   }
 `;
 
-export function ManageGamePage() {
+export default function ManageGamePage() {
   const {
     query: { season, week, game },
   } = useRouter();

--- a/pages/manage-games/[season]/[week]/[game]/index.tsx
+++ b/pages/manage-games/[season]/[week]/[game]/index.tsx
@@ -21,7 +21,7 @@ const GET_WEEK_BY_SLUG_QUERY = gql`
   }
 `;
 
-const GET_GAME_BY_SLUG_QUERY = gql`
+export const GET_GAME_BY_SLUG_QUERY = gql`
   query GET_GAME_BY_SLUG_QUERY($slug: String, $season: String) {
     games(
       where: {
@@ -53,7 +53,7 @@ const GET_GAME_BY_SLUG_QUERY = gql`
   }
 `;
 
-export default function ManageGamePage() {
+export function ManageGamePage() {
   const {
     query: { season, week, game },
   } = useRouter();
@@ -69,13 +69,18 @@ export default function ManageGamePage() {
     variables: { slug: game, season },
   });
   if (loading || gameLoading) return <p>Loading...</p>;
-  if (
-    error ||
-    gameError ||
-    gameData.games.length === 0 ||
-    data.weeks.length === 0
-  )
-    return <p>Error</p>;
+  if (error || gameError) {
+    return <p>Error: {error ? error.message : gameError?.message}</p>;
+  }
+
+  if (gameData.games.length === 0 || data.weeks.length === 0) {
+    return (
+      <p>
+        Error:{' '}
+        {gameData.games.length === 0 ? 'game not found' : 'week not found'}
+      </p>
+    );
+  }
 
   const weekData = data.weeks[0];
   const games = gameData.games[0];

--- a/pages/manage-games/[season]/[week]/index.tsx
+++ b/pages/manage-games/[season]/[week]/index.tsx
@@ -21,7 +21,7 @@ export const GET_WEEK_BY_SLUG_QUERY = gql`
   }
 `;
 
-export function ManageGamesPage() {
+export default function ManageGamesPage() {
   const {
     query: { season, week },
   } = useRouter();

--- a/pages/manage-games/[season]/[week]/index.tsx
+++ b/pages/manage-games/[season]/[week]/index.tsx
@@ -7,7 +7,7 @@ import ManageGames from '../../../../components/ManageGames';
 import Spacer from '../../../../components/Spacer';
 import PleaseSignIn from '../../../../components/PleaseSignIn';
 
-const GET_WEEK_BY_SLUG_QUERY = gql`
+export const GET_WEEK_BY_SLUG_QUERY = gql`
   query GET_WEEK_BY_SLUG_QUERY($slug: String, $season: String) {
     weeks(
       where: {
@@ -21,7 +21,7 @@ const GET_WEEK_BY_SLUG_QUERY = gql`
   }
 `;
 
-export default function ManageGamesPage() {
+export function ManageGamesPage() {
   const {
     query: { season, week },
   } = useRouter();

--- a/utils/testData.ts
+++ b/utils/testData.ts
@@ -20,6 +20,7 @@ const fakeGame = (overrides = {}) => ({
   winner: null,
   spread: 1,
   picks: [],
+  slug: 'falcons-jaguars',
   ...overrides,
 });
 

--- a/utils/testUtil.tsx
+++ b/utils/testUtil.tsx
@@ -2,13 +2,18 @@ import React, { ReactElement } from 'react';
 import { render, RenderOptions, RenderResult } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import { myTheme } from '../constants';
+import { SeasonProvider } from '../lib/seasonContext';
 
 type AllProvidersProps = {
   children: React.ReactElement;
 };
 
 const AllTheProviders = ({ children }: AllProvidersProps): ReactElement => {
-  return <ThemeProvider theme={myTheme}>{children}</ThemeProvider>;
+  return (
+    <ThemeProvider theme={myTheme}>
+      <SeasonProvider>{children}</SeasonProvider>
+    </ThemeProvider>
+  );
 };
 
 const customRender = (


### PR DESCRIPTION
* Adds unit tests for rest of pages: 
    * _app.tsx
    * gameResults
    * manageGame
    * manageGames
    * manageWeeks
    * reset
  
* Adds seasonProvider to test utils (this provider will be going away though)
*  Exports GET_GAME_BY_SLUG_QUERY from manageGame and GET_WEEK_BY_SLUG_QUERY from manageGames
* More detailed error handling in manageGame
* Adds slug to fakeGame in test util